### PR TITLE
Add "request" dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "koa-static": "^2.0.0",
     "mime-types": "2.1.11",
     "promise": "^7.1.1",
+    "request": "^2.75.0",
     "socket.io": "1.4.8",
     "tracer": "^0.8.0",
     "validator": "5.5.0",


### PR DESCRIPTION
`server/utils.js` requires 'request', which is not guaranteed to be installed globally.